### PR TITLE
Add "image-rendering: crisp-edges" to style

### DIFF
--- a/src/esheep.js
+++ b/src/esheep.js
@@ -193,7 +193,8 @@ class eSheep
         "transform:rotatey(0deg);" +
         "cursor:move;" +
         "z-index:2000;" +
-        "overflow:hidden;";
+        "overflow:hidden;" +
+        "image-rendering: crisp-edges;";
       this.DOMdiv.setAttribute("style", attribute);
       this.DOMdiv.appendChild(this.DOMimg);
 


### PR DESCRIPTION
Hi! This is my first pull request ever. I'm a big fan of this project. 

I've found that the default anti-aliasing on the images make them look a little fuzzy. Applying the crisp-edges image rendering style preserves the pixelated look of the sprites.

Before and after:
![crisp-edges](https://user-images.githubusercontent.com/13334709/131262389-2c837558-aa92-4b85-b8f9-ba058e84ef83.png)
